### PR TITLE
Update intact-db-updates version

### DIFF
--- a/cv-update-runner/pom.xml
+++ b/cv-update-runner/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.service</groupId>
         <artifactId>service-master</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>cv-update-runner</artifactId>

--- a/dataset-update-runner/pom.xml
+++ b/dataset-update-runner/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.service</groupId>
         <artifactId>service-master</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>dataset-update-runner</artifactId>

--- a/health-check/pom.xml
+++ b/health-check/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.service</groupId>
         <artifactId>service-master</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.5-SNAPSHOT</version>
     </parent>
     <artifactId>health-check</artifactId>
     <packaging>war</packaging>

--- a/imex-assigner-runner/pom.xml
+++ b/imex-assigner-runner/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.service</groupId>
         <artifactId>service-master</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>imex-assigner-runner</artifactId>

--- a/intact-publication-exporter/pom.xml
+++ b/intact-publication-exporter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.service</groupId>
         <artifactId>service-master</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.5-SNAPSHOT</version>
     </parent>
 
 

--- a/intact-widgets/pom.xml
+++ b/intact-widgets/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.service</groupId>
         <artifactId>service-master</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mutation-update-runner/pom.xml
+++ b/mutation-update-runner/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>service-master</artifactId>
         <groupId>uk.ac.ebi.intact.service</groupId>
-        <version>3.2.4</version>
+        <version>3.2.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <groupId>uk.ac.ebi.intact.service</groupId>
     <artifactId>service-master</artifactId>
     <packaging>pom</packaging>
-    <version>3.2.4</version>
+    <version>3.2.5-SNAPSHOT</version>
 
     <name>IntAct Services</name>
     <description>Services Master POM</description>
@@ -26,7 +26,7 @@
         <user>${env.USERNAME}</user>
         <appRoot>/intact</appRoot>
         <spring.version>4.3.30.RELEASE</spring.version>
-        <dbupdates.version>2.3.3</dbupdates.version>
+        <dbupdates.version>2.3.4-SNAPSHOT</dbupdates.version>
         <core.version>2.8.1</core.version>
         <bridges.version>2.2.2</bridges.version>
         <dataexchange.version>3.3.1</dataexchange.version>

--- a/protein-update-runner/pom.xml
+++ b/protein-update-runner/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.service</groupId>
         <artifactId>service-master</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.5-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Update intact-db-updates version to get a fix for the CV update runner.